### PR TITLE
Let RUNME script work from anywhere

### DIFF
--- a/RUNME.bat
+++ b/RUNME.bat
@@ -38,19 +38,22 @@ IF EXIST "%~dp0\Lethal Company.exe" (
        ECHO Lethal Company installation not found. Exiting...
        timeout /t 5 >nul
        pause
-       GOTO :EOF
+       exit
    )
 )
 
+REM Switch working directory to the Lethal Company installation folder
+cd /D "!LC_PATH!"
+
 ECHO Lethal Company installation found at !LC_PATH!.
 ECHO Removing modlist.txt and INSTALLER.bat
-if exist "!LC_PATH!\modlist.txt" del "!LC_PATH!\modlist.txt"
-if exist "!LC_PATH!\INSTALLER.bat" del "!LC_PATH!\INSTALLER.bat"
+if exist "modlist.txt" del "modlist.txt"
+if exist "INSTALLER.bat" del "INSTALLER.bat"
 
 REM Pull latest modlist.txt and INSTALLER.bat
 ECHO Downloading latest modlist.txt and INSTALLER.bat...
-powershell.exe -Command "& {Invoke-WebRequest -Uri 'https://raw.githubusercontent.com/rsm28/lethal_company_batch_files/main/modlist.txt' -OutFile '!LC_PATH!\modlist.txt'}"
-powershell.exe -Command "& {Invoke-WebRequest -Uri 'https://raw.githubusercontent.com/rsm28/lethal_company_batch_files/main/INSTALLER.bat' -OutFile '!LC_PATH!\INSTALLER.bat'}"
+powershell.exe -Command "& {Invoke-WebRequest -Uri 'https://raw.githubusercontent.com/rsm28/lethal_company_batch_files/main/modlist.txt' -OutFile '.\modlist.txt'}"
+powershell.exe -Command "& {Invoke-WebRequest -Uri 'https://raw.githubusercontent.com/rsm28/lethal_company_batch_files/main/INSTALLER.bat' -OutFile '.\INSTALLER.bat'}"
 
 REM Read the mods from the mods.txt file.
 ECHO ---
@@ -91,5 +94,8 @@ ECHO ---
 ECHO Running installer...
 
 REM Run backup version.bat
+REM Run the installer in a separate terminal so this RUNME closes and can be updated safely from INSTALLER
 ECHO Running INSTALLER.bat...
-call "!LC_PATH!\INSTALLER.bat"
+start "Lethal Company Mod Installer" /D "!LC_PATH!" "INSTALLER.bat" %~f0
+timeout /t 3 >nul
+exit


### PR DESCRIPTION
Primary change is switching the working directory of the scripts so it always works local to the Lethal Company install folder.  It also switches from a CALL to the installer to a START of the installer so that it can safely update the RUNME.bat script after installing the mods.

* Change directory to the Lethal Company install directory before attempting to run the rest of the runme script, and set the working directory of the installer script.
* Automatically update both runme scripts (LC install area and original location).
* If the installer script is not passed the original runme script location, or if the runme that was run is in the LC install area, it will only update the copy in the LC install area.